### PR TITLE
docs: add uv activation, CUDA device selection, fix model support status

### DIFF
--- a/docs/source/modules/getting_started/installation.rst
+++ b/docs/source/modules/getting_started/installation.rst
@@ -37,17 +37,8 @@ Step-by-Step Setup
       cd NewComputeBench
       git submodule update --init
 
-3. **Create the conda environment.**
 
-   .. code-block:: bash
-
-      conda env create -f environment.yaml
-
-4. **Activate the environment and install dependencies.**
-
-   .. code-block:: bash
-
-      conda activate new-compute
+3. **Activate the environment and install dependencies.**
 
    Install the required packages. Choose one option:
 
@@ -86,7 +77,7 @@ Step-by-Step Setup
 
          curl -LsSf https://astral.sh/uv/install.sh | sh
 
-5. **(Optional) Log in to Weights & Biases** to track experiment metrics.
+4. **(Optional) Log in to Weights & Biases** to track experiment metrics.
 
    .. code-block:: bash
 

--- a/docs/source/modules/getting_started/models.rst
+++ b/docs/source/modules/getting_started/models.rst
@@ -29,7 +29,7 @@ The table below lists all models currently targeted by NewComputeBench.
    * - Image classification
      - ``ViT-Base``
      - 86M
-     - ``google/vit-base-patch16-224`` from HuggingFace.
+     - `google/vit-base-patch16-224 <https://huggingface.co/google/vit-base-patch16-224>`_ from HuggingFace.
    * - Causal language modeling
      - TBD
      - TBD
@@ -132,16 +132,16 @@ Post-transform evaluation
    * - Random Bitflip
      - lm-eval-harness
      - ``AICrossSim-CLM``, ``Llama-3``
-     - ⏹️
+     - ✅
    * - Optical Compute
      - lm-eval-harness
      - ``AICrossSim-CLM``, ``Llama-3``
-     - ⏹️
+     - ✅
    * - In-Memory Compute
      - lm-eval-harness
      - ``AICrossSim-CLM``, ``Llama-3``
-     - ⏹️
+     - ✅
    * - Spiking Neural Networks
      - lm-eval-harness
      - ``AICrossSim-CLM``, ``Llama-3``
-     - ⏹️
+     - ✅

--- a/docs/source/modules/getting_started/quickstart.rst
+++ b/docs/source/modules/getting_started/quickstart.rst
@@ -13,6 +13,20 @@ Prerequisites
 Step 1 — Activate the environment
 ----------------------------------
 
+**uv** (activate venv):
+
+.. code-block:: bash
+
+   source .venv/bin/activate
+
+Or prefix every command with ``uv run`` to skip activation:
+
+.. code-block:: bash
+
+   uv run python run.py hf-gen ...
+
+**conda**:
+
 .. code-block:: bash
 
    conda activate new-compute
@@ -28,7 +42,7 @@ no local training needed.
 
    cd experiments/llm-digital/pretrain
 
-   python run.py hf-gen \
+   CUDA_VISIBLE_DEVICES=0 python run.py hf-gen \
        --model_name AICrossSim/clm-60m \
        --prompt "London is" \
        --max_new_tokens 100 \
@@ -37,6 +51,7 @@ no local training needed.
        --top_k 50 \
        --top_p 0.9
 
+Set ``CUDA_VISIBLE_DEVICES`` to the GPU index you want to use (e.g., ``0``, ``1``).
 You should see generated text printed to stdout within a few seconds.
 
 .. tip::
@@ -52,7 +67,7 @@ Evaluate the same checkpoint on ``wikitext`` using ``lm-eval-harness``:
 
 .. code-block:: bash
 
-   python run.py eval hf-lm-eval \
+   CUDA_VISIBLE_DEVICES=0 python run.py eval hf-lm-eval \
        AICrossSim/clm-60m \
        --tasks ['wikitext'] \
        --dtype float16

--- a/docs/source/modules/tutorials/pretraining/llm_pretrain_eval.rst
+++ b/docs/source/modules/tutorials/pretraining/llm_pretrain_eval.rst
@@ -39,6 +39,17 @@ AICrossSim-CLM-60M
    .. code-block:: bash
 
       cd experiments/llm-digital/pretrain
+
+   **uv:**
+
+   .. code-block:: bash
+
+      source .venv/bin/activate
+
+   **conda:**
+
+   .. code-block:: bash
+
       conda activate new-compute
 
 2. Generate the training config:
@@ -74,7 +85,9 @@ AICrossSim-CLM-60M
    .. code-block:: bash
 
       num_gpus="2"
+      cuda_devices="1,2"   # GPU indices to use, e.g. "0,1" for the first two GPUs
 
+      CUDA_VISIBLE_DEVICES=${cuda_devices} \
       PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True" STREAM_HF_DATA="1" \
       torchrun --nproc_per_node=${num_gpus} --rdzv_backend c10d \
           --rdzv_endpoint="localhost:0" --local-ranks-filter 0 \


### PR DESCRIPTION
- quickstart: add uv venv activation and uv run options, add CUDA_VISIBLE_DEVICES
- installation: separate uv/conda options more clearly
- models: mark post-transform evaluation as supported, add ViT HuggingFace link
- llm_pretrain_eval: add uv activation step, add CUDA_VISIBLE_DEVICES to torchrun