### PR TITLE
Fix bitflip-LoRA FSDP2 runnability: unify on 4 GPUs, uv-based env

### DIFF
--- a/docs/source/modules/tutorials/simulations/bitflip_lora_fsdp.rst
+++ b/docs/source/modules/tutorials/simulations/bitflip_lora_fsdp.rst
@@ -90,6 +90,13 @@ venv with::
    bash setup_env.sh
    source .venv/bin/activate
 
+``setup_env.sh`` uses `uv <https://docs.astral.sh/uv/>`_ (the same tool used by
+the parent project) to create ``.venv`` pinned to **Python 3.11**, which is
+required because ``train.py`` / ``eval.py`` use the stdlib ``tomllib`` module
+(3.11+). Install ``uv`` first if you don't have it
+(``curl -LsSf https://astral.sh/uv/install.sh | sh``); override the interpreter
+with ``PYTHON_VERSION=3.12 bash setup_env.sh`` if needed.
+
 .. note::
 
    ``train.py`` / ``eval.py`` add the repo's ``src/`` and the experiment's
@@ -237,19 +244,27 @@ training tokens, ≈ 700M tokens):
    cd experiments/llm-bitflip/lora_finetune_fsdp
    bash run.sh config_70b.toml
 
-which expands to (single 8-GPU node):
+which expands to (single 4-GPU node):
 
 .. code-block:: bash
 
-   torchrun --nproc_per_node=8 --nnodes=1 \
+   torchrun --nproc_per_node=4 --nnodes=1 \
        --master_addr=localhost --master_port=29500 \
        train.py --config config_70b.toml
+
+.. note::
+
+   ``--nproc_per_node`` must equal ``[parallelism].fsdp_degree`` in the config
+   (``4``). FSDP2 builds a 1-D device mesh of that size and ``init_device_mesh``
+   requires the mesh to span exactly ``WORLD_SIZE`` ranks, so a mismatch aborts
+   at startup. ``run.sh`` defaults to ``NPROC_PER_NODE=4`` to match; to use a
+   different GPU count, change both together.
 
 To override the step count from the command line:
 
 .. code-block:: bash
 
-   torchrun --nproc_per_node=8 train.py --config config_70b.toml --steps 21000
+   torchrun --nproc_per_node=4 train.py --config config_70b.toml --steps 21000
 
 For multi-node, set ``MASTER_ADDR`` / ``NNODES`` / ``NODE_RANK`` env vars per
 ``run.sh`` usage notes.

--- a/experiments/llm-bitflip/lora_finetune_fsdp/config_70b.toml
+++ b/experiments/llm-bitflip/lora_finetune_fsdp/config_70b.toml
@@ -1,8 +1,10 @@
-# Llama 3 70B bitflip-aware LoRA fine-tuning with FSDP2 on 8x B200
+# Llama 3 70B bitflip-aware LoRA fine-tuning with FSDP2 on 4x B200
 # Steps configurable via --steps CLI flag (default 20 for testing)
 #
+# nproc_per_node must equal [parallelism].fsdp_degree (4 below).
+#
 # Full run: ~21,000 steps (1% of 70B params = 700M tokens)
-#   torchrun --nproc_per_node=8 train.py --config config_70b.toml --steps 21000
+#   torchrun --nproc_per_node=4 train.py --config config_70b.toml --steps 21000
 
 [model]
 flavor = "70B"

--- a/experiments/llm-bitflip/lora_finetune_fsdp/run.sh
+++ b/experiments/llm-bitflip/lora_finetune_fsdp/run.sh
@@ -2,13 +2,13 @@
 # Launch bitflip-aware LoRA fine-tuning with FSDP2
 #
 # Usage:
-#   Single node, 8 GPUs:
+#   Single node, 4 GPUs (matches fsdp_degree=4 in config_70b.toml):
 #     bash run.sh
 #
 #   Custom config:
 #     bash run.sh config_debug.toml
 #
-#   Multi-node (2 nodes, 8 GPUs each):
+#   Multi-node (2 nodes, 4 GPUs each):
 #     # On node 0:
 #     MASTER_ADDR=<node0_ip> MASTER_PORT=29500 NNODES=2 NODE_RANK=0 bash run.sh
 #     # On node 1:
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG="${1:-${SCRIPT_DIR}/config_70b.toml}"
 
 # Distributed settings (override via env vars)
-NPROC_PER_NODE="${NPROC_PER_NODE:-8}"
+NPROC_PER_NODE="${NPROC_PER_NODE:-4}"
 NNODES="${NNODES:-1}"
 NODE_RANK="${NODE_RANK:-0}"
 MASTER_ADDR="${MASTER_ADDR:-localhost}"

--- a/experiments/llm-bitflip/lora_finetune_fsdp/setup_env.sh
+++ b/experiments/llm-bitflip/lora_finetune_fsdp/setup_env.sh
@@ -4,38 +4,54 @@
 # Usage:
 #   bash setup_env.sh
 #
-# This creates a venv at .venv/ and installs all dependencies.
+# This uses `uv` to create a venv at .venv/ pinned to a Python version that has
+# the stdlib `tomllib` module (>=3.11, required by train.py / eval.py), then
+# installs all dependencies. `uv` is the same tool used by the parent
+# NewComputeBench project. Install it from https://docs.astral.sh/uv/ if missing.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="${SCRIPT_DIR}/.venv"
+# train.py / eval.py `import tomllib`, which is stdlib only on Python >= 3.11.
+PYTHON_VERSION="${PYTHON_VERSION:-3.11}"
 
 echo "============================================="
 echo "Setting up environment for BitFlip LoRA FSDP2"
 echo "============================================="
 
-# ---- Create venv ----
+# ---- Check for uv ----
+if ! command -v uv >/dev/null 2>&1; then
+    echo "ERROR: 'uv' not found on PATH."
+    echo "Install it with:  curl -LsSf https://astral.sh/uv/install.sh | sh"
+    echo "or see https://docs.astral.sh/uv/getting-started/installation/"
+    exit 1
+fi
+echo "Using $(uv --version)"
+
+# ---- Create venv with a pinned Python (uv fetches it if not present) ----
 if [ ! -d "${VENV_DIR}" ]; then
-    echo "Creating virtual environment at ${VENV_DIR}..."
-    python3 -m venv "${VENV_DIR}"
+    echo "Creating virtual environment at ${VENV_DIR} (Python ${PYTHON_VERSION})..."
+    uv venv --python "${PYTHON_VERSION}" "${VENV_DIR}"
 else
     echo "Virtual environment already exists at ${VENV_DIR}"
 fi
 
 source "${VENV_DIR}/bin/activate"
+# Install into the venv created above (uv pip targets $VIRTUAL_ENV).
+echo "Active Python: $(python3 --version)"
 
 # ---- Install PyTorch (nightly for FSDP2 support) ----
 echo ""
 echo "Installing PyTorch nightly (CUDA 12.4)..."
 echo "If you need a different CUDA version, edit this script."
-pip install --upgrade pip
-pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu124
+uv pip install --upgrade pip
+uv pip install --prerelease=allow torch --index-url https://download.pytorch.org/whl/nightly/cu124
 
 # ---- Install triton ----
 echo ""
 echo "Installing Triton..."
-pip install triton
+uv pip install triton
 
 # ---- Install torchtitan (editable, from the submodule) ----
 # torchtitan/ is a git submodule pinned to commit 0e0590c1. If it's empty,
@@ -47,19 +63,18 @@ if [ ! -f "${SCRIPT_DIR}/torchtitan/pyproject.toml" ]; then
 fi
 echo ""
 echo "Installing torchtitan (editable)..."
-pip install -e "${SCRIPT_DIR}/torchtitan"
+uv pip install -e "${SCRIPT_DIR}/torchtitan"
 
 # ---- Install other dependencies ----
 echo ""
 echo "Installing remaining dependencies..."
-pip install \
+uv pip install \
     transformers \
     datasets \
     safetensors \
     tokenizers \
     accelerate \
     sentencepiece \
-    tomli \
     'mase-triton>=0.0.7'
 
 # ---- Verify installation ----
@@ -68,6 +83,13 @@ echo "============================================="
 echo "Verifying installation..."
 echo "============================================="
 python3 -c "
+import sys
+print(f'Python version: {sys.version.split()[0]}')
+
+# train.py / eval.py rely on stdlib tomllib (Python >= 3.11)
+import tomllib
+print('tomllib (stdlib): available')
+
 import torch
 print(f'PyTorch version: {torch.__version__}')
 print(f'CUDA available: {torch.cuda.is_available()}')
@@ -99,5 +121,5 @@ echo "To activate the environment:"
 echo "  source ${VENV_DIR}/bin/activate"
 echo ""
 echo "To run training:"
-echo "  bash run.sh                  # 8-GPU, Llama 3 70B (config_70b.toml)"
+echo "  bash run.sh                  # 4-GPU, Llama 3 70B (config_70b.toml)"
 echo "============================================="


### PR DESCRIPTION
## Summary

Two fixes that make the 70B bitflip-aware LoRA FSDP2 tutorial runnable end-to-end (found while auditing `docs/source/modules/tutorials/simulations/bitflip_lora_fsdp.rst` against `experiments/llm-bitflip/lora_finetune_fsdp/`).

### 1. Unify GPU count on 4
`config_70b.toml` sets `fsdp_degree = 4`, but `run.sh` and the docs defaulted to **8** processes. FSDP2 builds a 1-D device mesh of size `fsdp_degree`, and `init_device_mesh` requires it to span exactly `WORLD_SIZE` — so launching with 8 ranks aborted at startup. The actual reproduced run used 4 GPUs (consistent with the eval commands and the effective-batch math). Everything now says 4, with the `nproc_per_node == fsdp_degree` constraint documented.

### 2. `setup_env.sh` → uv with pinned Python 3.11
`train.py` / `eval.py` `import tomllib` (stdlib only on 3.11+), but `setup_env.sh` built the venv with the system `python3` (3.9 on the dev box) → immediate `ModuleNotFoundError`. Rewrote `setup_env.sh` to use **uv** (matching the parent NewComputeBench project) with a Python 3.11 venv, switched installs to `uv pip`, dropped the now-unused `tomli` backport, and added a `tomllib` import check. Docs Step 0 updated to match.

## Changes
- `run.sh` — `NPROC_PER_NODE` default 8→4; usage comments
- `config_70b.toml` — 4-GPU header/example + constraint note
- `setup_env.sh` — uv, pinned Python 3.11 (`PYTHON_VERSION` overridable), `uv pip` installs
- `bitflip_lora_fsdp.rst` — 4-GPU commands, mesh/`WORLD_SIZE` note, uv-based Step 0

## Testing
- Both shell scripts pass `bash -n`
- All Python files compile (`py_compile`)
- No stale 8-GPU references remain in the docs
- Not run: the actual 70B training/eval (requires B200s + gated weights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)